### PR TITLE
change "add to environment.rb" to "add to top of boot.rb"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ it could be something like::
 
   /usr/lib/ruby/1.9.1/x86_64-linux/mapscript.so
 
-add the path to your config/environment.rb, like this::
+add the path to the top of your config/boot.rb, like this::
 
   $: << '/usr/lib/ruby/1.9.1/x86_64-linux'
 


### PR DESCRIPTION
the failure to find mapscript.so happens before environment.rb is loaded.  Adding mapscript.so to the path in boot.rb makes sure it is available earlier on.
